### PR TITLE
Delete Toolbar from landing page, new account et new dog account

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,6 @@
   <body>
     <%= render "shared/flashes" %>
     <%= yield %>
-    <%= render "shared/toolbar" %>
+    <%= render "shared/toolbar" unless controller_name == "pages" || devise_controller? || (controller_name == "dogs") && action_name == "new" %>
   </body>
 </html>

--- a/app/views/shared/_toolbar.html.erb
+++ b/app/views/shared/_toolbar.html.erb
@@ -11,7 +11,7 @@
       <span>Spots</span>
     </div>
   <% end %>
-  <% if current_user %>
+  <% if current_user && current_user.dog %>
     <%= link_to dog_path(current_user.dog) do %>
       <div class="icone_3">
         <i class="fa-solid fa-dog"></i>


### PR DESCRIPTION
La toolbar n'est pas sur la landing page, la page de création de compte et la page de création du compte du chien. 
![Delete-Toolbar](https://user-images.githubusercontent.com/106148072/205615407-f9ed147a-a6b8-4171-a69d-4e6362491175.png)
