### PR TITLE
Fixing log out and log in path

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,8 @@ class ApplicationController < ActionController::Base
   def default_url_options
     { host: ENV["DOMAIN"] || "localhost:3000" }
   end
+
+  def after_sign_in_path_for(resource)
+    feeds_path
+  end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -15,9 +15,6 @@
       <div class="sign-in">
         <%= link_to "je m'inscris", new_user_registration_path, class: "btn btn-secondary" %>
       </div>
-      <div class="sign_out">
-      <%= link_to "log out", destroy_user_session_path, class: "btn btn-secondary" %>
-      </div>
     <% end %>
   </div>
   <div class="chien-mascotte-home">


### PR DESCRIPTION
LE bouton log out est parti de la landing page. Quand on se connecte, on est directement redirigé vers le feed.